### PR TITLE
Add ONNX runtime support for Green-on-Green detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,7 +1482,7 @@ camera_name = cam1
 |    `resolution_height`    |                        Integer                         |                                                                                      Height of the camera resolution (updated to 480).                                                                                      |
 |    `exp_compensation`     |                Integer between -8 and 8                |                                           Change the target exposure setting for the exposure algorithm. Defaults to -2, preferencing darker settings for faster shutter speeds.                                            |
 |     **GreenOnGreen**      |                                                        |                                                                                                                                                                                                                             |
-|       `model_path`        |                          Path                          |                                                                                                  A path to the model file                                                                                                   |
+|       `model_path`        |                          Path                          | Path to the weed-detection model (.onnx or .tflite) |
 |       `confidence`        |                                                        |                                                                            The cutoff confidence value for a detection. Defaults to 0.5 or 50%.                                                                             |
 |     `class_filter_id`     |                        Integer                         |                           Which classes to filter and target. For example, using a out-the-box COCO model, you may want to only detect a specific class. Enter that specific class integer here.                            |
 |     **GreenOnBrown**      |                                                        |                                                                                                                                                                                                                             |
@@ -1722,13 +1722,12 @@ With the config files set, save them to the OWL, reboot, and you should be ready
 
 ### OWL Integration
 
-Green-on-Green capability is (almost) here!
-
-While we previously had implemented in-crop detection models with the Google Coral and Pycoral, the lack of support
-has made us reconsider that approach. Running detection models like YOLO is in the works to run on the base Raspberry Pi
-5 or with additional hardware such as the Raspberry Pi AI Kit with the Hailo 8L.
-
-If you would like to try the Google Coral, you can by following the instructions in the 'models' directory.
+Green-on-Green capability is now supported through ONNX Runtime.
+This allows running detection models such as YOLO on the Raspberry Pi 5
+without additional hardware. An example configuration file is
+available at `config/ONNX_GOG.ini`. The software will still use Google
+Coral TensorFlow Lite models when provided – see the instructions in the
+`models` directory if you are using a Coral accelerator.
 
 
 ### Model Training
@@ -1738,9 +1737,9 @@ start collecting and annotating images of relevant weeds for training. Alternati
 to [Weed-AI](https://weed-ai.sydney.edu.au/explore?is_head_filter=%5B%22latest+version%22%5D) to see if any image data
 may be relevant for your purposes.
 
->⚠️**NOTE**⚠️There do appear to be some issues with the exporting functionality of YOLOv5/v8 to .tflite models for use with
-the Coral. The issue has been raised on the Ultralytics repository and should hopefully be resolved soon. You can follow
-the updates [here](https://github.com/ultralytics/ultralytics/issues/1312).
+>⚠️**NOTE**⚠️ Exporting YOLOv5/v8 models to `.tflite` for the Coral can be
+unreliable. Exporting to ONNX (e.g. `yolo export model=best.pt format=onnx`)
+is recommended for running on the Raspberry Pi 5.
 
 [YOLOv8](https://github.com/ultralytics/ultralytics) and [YOLOv5](https://github.com/ultralytics/yolov5) currently
 provide the most user friendly methods of training, optimisation and exporting as `.tflite` files for use with the

--- a/config/ONNX_GOG.ini
+++ b/config/ONNX_GOG.ini
@@ -1,0 +1,46 @@
+[System]
+# Example configuration for running an ONNX Green-on-Green model
+algorithm = gog
+input_file_or_directory =
+relay_num = 4
+actuation_duration = 0.15
+delay = 0
+
+[Camera]
+resolution_width = 416
+resolution_height = 320
+exp_compensation = -2
+
+[GreenOnGreen]
+# Path to a directory containing models or a single .onnx file
+model_path = models
+confidence = 0.5
+class_filter_id = None
+
+[GreenOnBrown]
+exg_min = 25
+exg_max = 200
+hue_min = 41
+hue_max = 80
+saturation_min = 52
+saturation_max = 218
+brightness_min = 62
+brightness_max = 188
+min_detection_area = 20
+invert_hue = False
+
+[DataCollection]
+sample_images = False
+sample_method = whole
+sample_frequency = 30
+save_directory = /media/owl/SanDisk
+disable_detection = False
+log_fps = False
+camera_name = cam1
+
+[Relays]
+0 = 13
+1 = 15
+2 = 16
+3 = 18
+

--- a/environment.yml
+++ b/environment.yml
@@ -19,3 +19,4 @@ dependencies:
       - glob2==0.7
       - gpiozero==1.6.2
       - opencv-contrib-python
+      - onnxruntime

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
       - glob2==0.7
       - gpiozero==1.6.2
       - opencv-contrib-python
-      - onnxruntime
+      - onnxruntime>=1.15.0

--- a/models/README.md
+++ b/models/README.md
@@ -1,6 +1,18 @@
 # Adding Green-on-Green to the OWL (beta)
 Welcome to the first iteration of Green-on-Green or in-crop weed detection with the OWL. This is still an early beta version, so it may require additional troubleshooting. It has been tested and works on both a Raspberry Pi 4, LibreComputer and a Windows desktop computer.
 
+## ONNX Runtime on Raspberry Pi 5
+If you do not have a Google Coral accelerator, the OWL can now run
+Green-on-Green detection using ONNX models on the Raspberry Pi 5. Install
+the ONNX Runtime with:
+
+```
+pip install onnxruntime
+```
+
+Place your `.onnx` model in this directory and update the `model_path`
+in your configuration file (for example, `config/ONNX_GOG.ini`).
+
 ## Stage 1| Hardware/Software - Google Coral Installation
 In addition to the other software installation to get the OpenWeedLocator running, you will also need to install the Google Coral supporting software onto the Raspberry Pi. Simply run `install_coral.sh` from the command line using the instructions below. 
 

--- a/non_rpi_requirements.txt
+++ b/non_rpi_requirements.txt
@@ -5,3 +5,4 @@ imutils==0.5.4
 numpy==1.23.4
 opencv-python==4.6.0.66
 pandas==1.5.1
+onnxruntime

--- a/non_rpi_requirements.txt
+++ b/non_rpi_requirements.txt
@@ -5,4 +5,4 @@ imutils==0.5.4
 numpy==1.23.4
 opencv-python==4.6.0.66
 pandas==1.5.1
-onnxruntime
+onnxruntime==1.15.0

--- a/owl.py
+++ b/owl.py
@@ -332,6 +332,13 @@ class Owl:
                 from utils.greenongreen import GreenOnGreen
                 model_path = self.config.get('GreenOnGreen', 'model_path')
                 confidence = self.config.getfloat('GreenOnGreen', 'confidence')
+                class_filter_id = self.config.get(
+                    'GreenOnGreen', 'class_filter_id', fallback=None
+                )
+                if class_filter_id in (None, '', 'None'):
+                    class_filter_id = None
+                else:
+                    class_filter_id = int(class_filter_id)
 
                 weed_detector = GreenOnGreen(model_path=model_path)
 
@@ -389,7 +396,7 @@ class Owl:
                         cnts, boxes, weed_centres, image_out = weed_detector.inference(
                             frame,
                             confidence=confidence,
-                            filter_id=63
+                            filter_id=class_filter_id,
                         )
                     else:
                         cnts, boxes, weed_centres, image_out = weed_detector.inference(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm
 blessed
 matplotlib
 Pillow>=11.2.1,<11.3.0
+onnxruntime

--- a/utils/greenongreen.py
+++ b/utils/greenongreen.py
@@ -62,7 +62,6 @@ class GreenOnGreen:
         self.backend = None
 
         if self.model_path.suffix == ".onnx":
-            import onnxruntime as ort
 
             self.backend = "onnx"
             self.session = ort.InferenceSession(

--- a/utils/greenongreen.py
+++ b/utils/greenongreen.py
@@ -151,6 +151,9 @@ class GreenOnGreen:
             detections = self.session.run(None, {self.input_name: img_input})[0][0]
 
             for det in detections:
+                if len(det) < 5:
+                    # Skip detections with unexpected format
+                    continue
                 x, y, w, h, obj_conf, *class_conf = det
                 if not class_conf:
                     class_conf = [1.0]

--- a/utils/greenongreen.py
+++ b/utils/greenongreen.py
@@ -77,7 +77,6 @@ class GreenOnGreen:
             from pycoral.adapters.common import input_size
             from pycoral.adapters.detect import get_objects
             from pycoral.utils.edgetpu import make_interpreter, run_inference
-
             self.backend = "tflite"
             self._run_inference = run_inference
             self._get_objects = get_objects

--- a/utils/greenongreen.py
+++ b/utils/greenongreen.py
@@ -155,7 +155,7 @@ class GreenOnGreen:
                     # Skip detections with unexpected format
                     continue
                 x, y, w, h, obj_conf, *class_conf = det
-                if not class_conf:
+                if len(class_conf) == 0:
                     class_conf = [1.0]
                 class_id = int(np.argmax(class_conf))
                 score = obj_conf * class_conf[class_id]

--- a/utils/greenongreen.py
+++ b/utils/greenongreen.py
@@ -1,92 +1,192 @@
 #!/usr/bin/env python
-from pycoral.adapters.common import input_size
-from pycoral.adapters.detect import get_objects
-from pycoral.utils.dataset import read_label_file
-from pycoral.utils.edgetpu import make_interpreter
-from pycoral.utils.edgetpu import run_inference
+"""Green-on-Green weed detection.
+
+This module now supports running either TensorFlow Lite models on the
+Google Coral or ONNX models via the ONNX Runtime.  When a directory is
+provided it will attempt to load the first ``.onnx`` or ``.tflite`` file
+alphabetically.
+
+The ONNX branch is designed to run on the Raspberry Pi 5 without
+additional accelerators.
+"""
+
 from pathlib import Path
 
 import cv2
+import numpy as np
 
 
 class GreenOnGreen:
-    def __init__(self, model_path='models', label_file='models/labels.txt'):
+    def __init__(self, model_path="models", label_file="models/labels.txt"):
         if model_path is None:
-            print('[WARNING] No model directory or path provided with --model-path flag. '
-                  'Attempting to load from default...')
-            model_path = 'models'
+            print(
+                "[WARNING] No model directory or path provided with --model-path "
+                "flag. Attempting to load from default..."
+            )
+            model_path = "models"
+
         self.model_path = Path(model_path)
 
         if self.model_path.is_dir():
-            model_files = list(self.model_path.glob('*.tflite'))
+            model_files = sorted(
+                list(self.model_path.glob("*.onnx"))
+                + list(self.model_path.glob("*.tflite"))
+            )
             if not model_files:
-                raise FileNotFoundError('No .tflite model files found. Please provide a directory or .tflite file.')
+                raise FileNotFoundError(
+                    "No .onnx or .tflite model files found. Please provide a directory "
+                    "or model file."
+                )
+            self.model_path = model_files[0]
+            print(f"[INFO] Using {self.model_path.stem} model...")
 
-            else:
-                self.model_path = model_files[0]
-                print(f'[INFO] Using {self.model_path.stem} model...')
-
-        elif self.model_path.suffix == '.tflite':
-            print(f'[INFO] Using {self.model_path.stem} model...')
+        elif self.model_path.suffix in {".onnx", ".tflite"}:
+            print(f"[INFO] Using {self.model_path.stem} model...")
 
         else:
-            print(f'[WARNING] Specified model path {model_path} is unsupported, attempting to use default...')
-
-            model_files = Path('models').glob('*.tflite')
+            print(
+                f"[WARNING] Specified model path {model_path} is unsupported, "
+                "attempting to use default..."
+            )
+            model_files = sorted(
+                list(Path("models").glob("*.onnx"))
+                + list(Path("models").glob("*.tflite"))
+            )
             try:
-                self.model_path = next(model_files)
-                print(f'[INFO] Using {self.model_path.stem} model...')
+                self.model_path = model_files[0]
+                print(f"[INFO] Using {self.model_path.stem} model...")
+            except IndexError:
+                raise FileNotFoundError("No model files found.")
 
-            except StopIteration:
-                print('[ERROR] No model files found.')
+        self.labels = self._read_label_file(label_file)
+        self.backend = None
 
-        self.labels = read_label_file(label_file)
-        self.interpreter = make_interpreter(self.model_path.as_posix())
-        self.interpreter.allocate_tensors()
-        self.inference_size = input_size(self.interpreter)
-        self.objects = None
+        if self.model_path.suffix == ".onnx":
+            import onnxruntime as ort
 
-    def inference(self, image, confidence=0.5, filter_id=0):
-        cv2_im_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        cv2_im_rgb = cv2.resize(cv2_im_rgb, self.inference_size)
-        run_inference(self.interpreter, cv2_im_rgb.tobytes())
-        self.objects = get_objects(self.interpreter, confidence)
-        self.filter_id = filter_id
+            self.backend = "onnx"
+            self.session = ort.InferenceSession(
+                self.model_path.as_posix(), providers=["CPUExecutionProvider"]
+            )
+            input_shape = self.session.get_inputs()[0].shape
+            # input shape expected as [batch, channels, height, width]
+            self.input_name = self.session.get_inputs()[0].name
+            self.inference_size = (input_shape[3], input_shape[2])
 
-        height, width, channels = image.shape
-        scale_x, scale_y = width / self.inference_size[0], height / self.inference_size[1]
-        self.weed_centers = []
+        elif self.model_path.suffix == ".tflite":
+            from pycoral.adapters.common import input_size
+            from pycoral.adapters.detect import get_objects
+            from pycoral.utils.edgetpu import make_interpreter, run_inference
+
+            self.backend = "tflite"
+            self._run_inference = run_inference
+            self._get_objects = get_objects
+            self.interpreter = make_interpreter(self.model_path.as_posix())
+            self.interpreter.allocate_tensors()
+            self.inference_size = input_size(self.interpreter)
+
+        else:
+            raise ValueError(
+                "Unsupported model format. Expected .onnx or .tflite file."
+            )
+
+    @staticmethod
+    def _read_label_file(label_file):
+        labels = {}
+        path = Path(label_file)
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f.readlines():
+                    pair = line.strip().split(maxsplit=1)
+                    if len(pair) == 2 and pair[0].isdigit():
+                        labels[int(pair[0])] = pair[1]
+        return labels
+
+    def inference(self, image, confidence=0.5, filter_id=None):
+        height, width, _ = image.shape
         self.boxes = []
+        self.weed_centers = []
 
-        for det_object in self.objects:
-            if det_object.id == self.filter_id:
+        if self.backend == "tflite":
+            cv2_im_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            cv2_im_rgb = cv2.resize(cv2_im_rgb, self.inference_size)
+            self._run_inference(self.interpreter, cv2_im_rgb.tobytes())
+            objects = self._get_objects(self.interpreter, confidence)
+
+            scale_x = width / self.inference_size[0]
+            scale_y = height / self.inference_size[1]
+
+            for det_object in objects:
+                if filter_id is not None and det_object.id != filter_id:
+                    continue
                 bbox = det_object.bbox.scale(scale_x, scale_y)
 
-                startX, startY = int(bbox.xmin), int(bbox.ymin)
-                endX, endY = int(bbox.xmax), int(bbox.ymax)
-                boxW = endX - startX
-                boxH = endY - startY
+                start_x, start_y = int(bbox.xmin), int(bbox.ymin)
+                end_x, end_y = int(bbox.xmax), int(bbox.ymax)
+                box_w = end_x - start_x
+                box_h = end_y - start_y
 
-                # save the bounding box
-                self.boxes.append([startX, startY, boxW, boxH])
-                # compute box center
-                centerX = int(startX + (boxW / 2))
-                centerY = int(startY + (boxH / 2))
-                self.weed_centers.append([centerX, centerY])
+                self.boxes.append([start_x, start_y, box_w, box_h])
+                center_x = int(start_x + (box_w / 2))
+                center_y = int(start_y + (box_h / 2))
+                self.weed_centers.append([center_x, center_y])
 
                 percent = int(100 * det_object.score)
-                label = f'{percent}% {self.labels.get(det_object.id, det_object.id)}'
-                cv2.rectangle(image, (startX, startY), (endX, endY), (0, 0, 255), 2)
-                cv2.putText(image, label, (startX, startY + 30),
-                                     cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 0, 0), 2)
-            else:
-                pass
-        # print(self.weedCenters)
+                label = f"{percent}% {self.labels.get(det_object.id, det_object.id)}"
+                cv2.rectangle(image, (start_x, start_y), (end_x, end_y), (0, 0, 255), 2)
+                cv2.putText(
+                    image,
+                    label,
+                    (start_x, start_y + 30),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    1.0,
+                    (255, 0, 0),
+                    2,
+                )
+
+        else:  # ONNX
+            img_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            img_resized = cv2.resize(img_rgb, self.inference_size)
+            img_norm = img_resized.astype(np.float32) / 255.0
+            img_input = np.transpose(img_norm, (2, 0, 1))[np.newaxis, :]
+
+            detections = self.session.run(None, {self.input_name: img_input})[0][0]
+
+            for det in detections:
+                x, y, w, h, obj_conf, *class_conf = det
+                if not class_conf:
+                    class_conf = [1.0]
+                class_id = int(np.argmax(class_conf))
+                score = obj_conf * class_conf[class_id]
+                if score < confidence:
+                    continue
+                if filter_id is not None and class_id != filter_id:
+                    continue
+
+                x1 = int((x - w / 2) * width / self.inference_size[0])
+                y1 = int((y - h / 2) * height / self.inference_size[1])
+                x2 = int((x + w / 2) * width / self.inference_size[0])
+                y2 = int((y + h / 2) * height / self.inference_size[1])
+                box_w = x2 - x1
+                box_h = y2 - y1
+
+                self.boxes.append([x1, y1, box_w, box_h])
+                center_x = int(x1 + box_w / 2)
+                center_y = int(y1 + box_h / 2)
+                self.weed_centers.append([center_x, center_y])
+
+                percent = int(score * 100)
+                label = self.labels.get(class_id, str(class_id))
+                cv2.rectangle(image, (x1, y1), (x2, y2), (0, 0, 255), 2)
+                cv2.putText(
+                    image,
+                    f"{percent}% {label}",
+                    (x1, y1 + 30),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    1.0,
+                    (255, 0, 0),
+                    2,
+                )
+
         return None, self.boxes, self.weed_centers, image
-
-
-
-
-
-
 


### PR DESCRIPTION
## Summary
- add ONNX Runtime pipeline to `GreenOnGreen` for running `.onnx` models on Raspberry Pi 5
- load Green-on-Green model and class filters from config, with example `config/ONNX_GOG.ini`
- document ONNX setup and update dependencies to include `onnxruntime`

## Testing
- `python -m py_compile utils/greenongreen.py owl.py`


------
https://chatgpt.com/codex/tasks/task_e_6897dd0b6ce48321a0716b2ae7811c95