### PR TITLE
Add utility to ensure Jupyter notebook outputs field

### DIFF
--- a/utils/ensure_notebook_outputs.py
+++ b/utils/ensure_notebook_outputs.py
@@ -1,0 +1,37 @@
+"""Utility to ensure all code cells in a Jupyter notebook include an `outputs` key.
+
+This helps avoid nbformat validation errors that report "'outputs' is a required property".
+
+Usage:
+    python utils/ensure_notebook_outputs.py <notebook.ipynb>
+"""
+
+from __future__ import annotations
+
+import sys
+import nbformat
+
+
+def ensure_outputs(notebook_path: str) -> None:
+    """Add an empty `outputs` list to any code cell missing one.
+
+    Parameters
+    ----------
+    notebook_path: str
+        Path to the notebook file to update.
+    """
+    nb = nbformat.read(notebook_path, as_version=4)
+    changed = False
+    for cell in nb.cells:
+        if cell.get("cell_type") == "code" and "outputs" not in cell:
+            cell["outputs"] = []
+            changed = True
+    if changed:
+        nbformat.write(nb, notebook_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python utils/ensure_notebook_outputs.py <notebook.ipynb>")
+        sys.exit(1)
+    ensure_outputs(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `ensure_notebook_outputs.py` helper to add missing `outputs` fields to Jupyter code cells

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2eeb8ce48321abe73fc0bff158ca